### PR TITLE
nxus-searcher-preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ module.exports = {
 
 If your project uses searcher/elasticsearch, use the preset `nxus-tester-jest/nxus-searcher-preset` instead. A test index at `localhost:9200/searcher-jest-test` will be created on setup and deleted on teardown, and configured for the `searcher` storage connection.
 
+You probably want to call `await tester.searcherRefresh()` in your tests after documents are indexed to ensure search has the latest documents.
+
 
 If you need to specify a custom server script or environment vars for `nxus-tester` `startTestServer`, add `testEnvironmentOptions`:
 ```

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ module.exports = {
 }
 ```
 
-If you need to specify a custom server script for `nxus-tester` `startTestServer`, create a file `jest-nxus.config.js`:
+If your project uses searcher/elasticsearch, use the preset `nxus-tester-jest/nxus-searcher-preset` instead. A test index at `localhost:9200/searcher-jest-test` will be created on setup and deleted on teardown, and configured for the `searcher` storage connection.
+
+
+If you need to specify a custom server script or environment vars for `nxus-tester` `startTestServer`, add `testEnvironmentOptions`:
 ```
 module.exports = {
-  server: 'index-test.js'
+  testEnvironmentOptions: {server: 'index-test.js', serverEnv: {nxus_storage...: '...'}}
 }
 ```
-

--- a/nxus-environment.js
+++ b/nxus-environment.js
@@ -11,6 +11,7 @@ const tester = require('nxus-tester')
 const application = require('nxus-core').application
 const storage = require('nxus-storage').storage
 
+
 class MongoEnvironment extends NodeEnvironment {
   constructor(config) {
     super(config);
@@ -73,23 +74,21 @@ class PuppeteerEnvironment extends MongoEnvironment {
 
 
 class NxusEnvironment extends PuppeteerEnvironment {
+  constructor(config) {
+    super(config);
+    this.config = Object.assign({server: 'index.js'}, config.testEnvironmentOptions)
+  }
+
   async setup() {
     console.log('Setup Nxus Test Environment');
     await super.setup();
-
-    let config = {server: 'index.js'}
-    try {
-      Object.assign(config, require(path.resolve(process.cwd(), 'jest-nxus.config.js')))
-    } catch(e) {
-      console.log(" No jest-nxus.config.js?", e.message)
-    }
     
-    let opts = {
+    let opts = Object.assign({
       watch: false,
-      DEBUG: "nxus:*",
+      DEBUG: (process.env.DEBUG || ""),
       nxus_storage__connections__default__url: this.global.__MONGO_URI__
-    }
-    await tester.startTestServer(config.server, opts)
+    }, this.config.serverEnv || {})
+    await tester.startTestServer(this.config.server, opts)
 
     this.global.tester = tester
     this.global.application = application

--- a/nxus-searcher-environment.js
+++ b/nxus-searcher-environment.js
@@ -1,0 +1,45 @@
+const NxusEnvironment = require('./nxus-environment')
+const tester = require('nxus-tester')
+
+class NxusSearcherEnvironment extends NxusEnvironment {
+  constructor(config) {
+    if (!config.testEnvironmentOptions) {
+      config.testEnvironmentOptions = {}
+    }
+    if (!config.testEnvironmentOptions.serverEnv) {
+      config.testEnvironmentOptions.serverEnv = {}
+    }
+    if (!config.testEnvironmentOptions.serverEnv.nxus_storage__connections__searcher__index) {
+      config.testEnvironmentOptions.serverEnv.nxus_storage__connections__searcher__index = 'searcher-jest-test'
+    }
+    if (!config.testEnvironmentOptions.serverEnv.nxus_storage__connections__searcher__host) {
+      config.testEnvironmentOptions.serverEnv.nxus_storage__connections__searcher__host = 'localhost:9200'
+    }
+    super(config)
+
+    this.searcherHost = config.testEnvironmentOptions.serverEnv.nxus_storage__connections__searcher__host
+    this.searcherIndexName = config.testEnvironmentOptions.serverEnv.nxus_storage__connections__searcher__index
+    this.searcherIndex = this.searcherHost+'/'+this.searcherIndexName
+  }
+
+  async setup() {
+    console.log("Setting up searcher index at", this.searcherIndex)
+    try {
+      await tester.request.put({url:'http://'+this.searcherIndex, baseUrl: null})
+    } catch (e) {
+      console.log("ES error", e)
+    }
+    return super.setup()
+  }
+  async teardown() {
+    console.log("Tearing down searcher index", this.searcherIndex)
+    try {
+      await tester.request.delete({url:'http://'+this.searcherIndex, baseUrl: null})
+    } catch (e) {
+      console.log("ES error", e)
+    }
+    return super.teardown()
+  }
+}
+
+module.exports = NxusSearcherEnvironment

--- a/nxus-searcher-preset/jest-preset.json
+++ b/nxus-searcher-preset/jest-preset.json
@@ -1,0 +1,14 @@
+{
+  "globalSetup": "nxus-tester-jest/setup",
+  "globalTeardown": "nxus-tester-jest/teardown",
+  "testEnvironment": "nxus-tester-jest/nxus-searcher-environment",
+  "testMatch": [
+     "**/__tests__/**/*.js?(x)",
+     "**/test/**/*.js?(x)",
+     "**/?(*.)+(spec|test).js?(x)"
+   ],
+  "testPathIgnorePatterns": [
+     "/node_modules/",
+     "/lib/"
+   ]
+}


### PR DESCRIPTION
Adds a preset and environment for nxus apps using searcher / elasticsearch to manage setup/teardown of an ephemeral search index.

Also gets rid of the jest-nxus.config.js file and reads the main jest `testEnvironmentOptions` key instead for overriding server and env settings.