### PR TITLE
Setup fix for heroku CI of mongodb-memory-server

### DIFF
--- a/nxus-environment.js
+++ b/nxus-environment.js
@@ -86,7 +86,6 @@ class NxusEnvironment extends PuppeteerEnvironment {
     let opts = Object.assign({
       watch: false,
       DEBUG: "",
-      nxus_storage__defaults__migrate: "safe",
       nxus_storage__connections__default__url: this.global.__MONGO_URI__
     }, this.config.serverEnv || {})
     await tester.startTestServer(this.config.server, opts)

--- a/setup.js
+++ b/setup.js
@@ -9,7 +9,6 @@ const os = require('os');
 const DIR = path.join(os.tmpdir(), 'jest_global_setup');
 
 async function setupMongo() {
-  console.log("mongo before")
   const mongod = new MongodbMemoryServer.default({
     instance: {
       dbName: 'jest'
@@ -18,15 +17,12 @@ async function setupMongo() {
   //    version: '3.4.10'
   //  }
   });
-  console.log("mongo created")
 
   const mongoConfig = {
     mongoDBName: 'jest',
     mongoUri: await mongod.getConnectionString()
   };
   
-  console.log("mongo connection", mongoConfig)
-
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(path.join(DIR, 'globalConfig'), JSON.stringify(mongoConfig));
 

--- a/setup.js
+++ b/setup.js
@@ -8,21 +8,24 @@ const os = require('os');
 
 const DIR = path.join(os.tmpdir(), 'jest_global_setup');
 
-
-const mongod = new MongodbMemoryServer.default({
-  instance: {
-    dbName: 'jest'
-  }//,
-//  binary: {
-//    version: '3.4.10'
-//  }
-});
-
 async function setupMongo() {
+  console.log("mongo before")
+  const mongod = new MongodbMemoryServer.default({
+    instance: {
+      dbName: 'jest'
+    }//,
+  //  binary: {
+  //    version: '3.4.10'
+  //  }
+  });
+  console.log("mongo created")
+
   const mongoConfig = {
     mongoDBName: 'jest',
     mongoUri: await mongod.getConnectionString()
   };
+  
+  console.log("mongo connection", mongoConfig)
 
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(path.join(DIR, 'globalConfig'), JSON.stringify(mongoConfig));

--- a/setup.js
+++ b/setup.js
@@ -46,6 +46,9 @@ async function setupPuppeteer() {
 
 module.exports = async function() {
   mkdirp.sync(DIR);
+  console.log("Setup: created", DIR)
   await setupMongo()
+  console.log("Setup: mongo at", process.env.MONGO_URL)
   await setupPuppeteer()
+  console.log("Setup: puppeteer started")
 }


### PR DESCRIPTION
No current idea why this causes a silent no-op for test running on some heroku ci configs, but this works for both.